### PR TITLE
Update Base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,6 @@ RUN apt-get update                      &&      \
     apt-get upgrade -y                     &&      \
     apt-get install -y                          \
         curl                                    \
-        lib32gcc1				\
-	lib32tinfo5				\
-	libncurses5				\
-	libncurses5:i386			\
 	libc6:i386				\
 	libstdc++6:i386				\
 	lib32z1					\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 MAINTAINER Jason Rivers <docker@jasonrivers.co.uk
 


### PR DESCRIPTION
TeamFortess 2 now needs the GLIBC 2.29